### PR TITLE
FIx configuring secondary ESP on xavier-agx

### DIFF
--- a/modules/devices.nix
+++ b/modules/devices.nix
@@ -110,19 +110,17 @@ in lib.mkMerge [{
   # https://forums.developer.nvidia.com/t/setting-uefi-variables-using-the-defaultvariabledxe-only-works-if-esp-is-on-emmc-but-not-on-an-nvme-drive/250254
   # We don't mount this at /boot, because we still want to allow the user to have their ESP part on NVMe, or whatever else.
   fileSystems."/opt/nvidia/esp" = lib.mkDefault {
-    config = {
-      device = "/dev/disk/by-partlabel/esp";
-      fsType = "vfat";
-      options = [ "nofail" ];
-      # Since we have NO_ESP_IMG=1 while formatting, the script doesn't
-      # actually create an FS here, so we'll do it automatically
-      autoFormat = true;
-      formatOptions =
-        if (lib.versionAtLeast config.system.nixos.release "23.05") then
-          null
-        else
-          "-F 32 -n ESP";
-    };
+    device = "/dev/disk/by-partlabel/esp";
+    fsType = "vfat";
+    options = [ "nofail" ];
+    # Since we have NO_ESP_IMG=1 while formatting, the script doesn't
+    # actually create an FS here, so we'll do it automatically
+    autoFormat = true;
+    formatOptions =
+      if (lib.versionAtLeast config.system.nixos.release "23.05") then
+        null
+      else
+        "-F 32 -n ESP";
   };
 })
 ]


### PR DESCRIPTION
###### Description of changes

It appears that the top-level `config` attribute cannot exist for the submodule `fileSystems.<name>`. Fix configuring this mount by removing that attribute.



<!--
What has changed as a result of this PR? Why was the change made?
-->

###### Testing

Successfully build `config.system.build.toplevel` for a nixos system for an xavier-agx board.
<!--
If applicable, please mention what was done to test this change.
What SoM and carrier board was this change tested on? e.g. Xavier AGX devkit
-->
